### PR TITLE
fix(eco_governance): restrict balance burning function to privileged pauser accounts

### DIFF
--- a/src/migration/upgrades/L2ECOxZero.sol
+++ b/src/migration/upgrades/L2ECOxZero.sol
@@ -47,9 +47,11 @@ contract L2ECOxZero is L2ECOxFreeze {
 
     /**
      * @dev Burns the entire ECOx balance of each address in the input array
+     * @dev Restricted to pausers: the function toggles the pause state and destroys
+     * arbitrary balances, so it must never be callable by an unprivileged account
      * @param accounts The array of addresses whose balances will be burned
      */
-    function burnBalances(address[] calldata accounts) external {
+    function burnBalances(address[] calldata accounts) external onlyPauser {
         // Unpause to allow transfers
         _unpause();
 


### PR DESCRIPTION
### Description
This PR addresses a critical access control vulnerability within the `eco_governance` repository (`src/migration/upgrades/L2ECOxZero.sol`)[cite: 32]. Previously, the `burnBalances` function lacked appropriate permissions, allowing any unprivileged account to toggle the pause state and destroy arbitrary account balances[cite: 32]. 

### Key Changes
* **Access Control Enforcement (`src/migration/upgrades/L2ECOxZero.sol`):**
  - Added the `onlyPauser` modifier to the `burnBalances` function, ensuring that only accounts with authorized pauser permissions can trigger the pause/unpause and balance destruction sequence[cite: 32].

### Validation & Testing
* **Static Verification:** The access control modifier aligns correctly with the governance requirements, preventing unprivileged execution[cite: 32].
* **Reviewer Action Required:** Full compiler and test executions (`forge` or `solc`) were unavailable during the offline audit because the required toolchains are absent. A maintainer must execute the native smart contract test suite locally to verify state upgrades and modifier behavior before merging.